### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 A Model Context Protocol server that makes it easy to discover and copy available MCP services in Claude Desktop.
 
+<a href="https://glama.ai/mcp/servers/@fisheepx/mcp-easy-copy">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@fisheepx/mcp-easy-copy/badge" alt="Easy Copy MCP server" />
+</a>
+
 <img src="docs/images/screenshot.png" alt="MCP Easy Copy in action" width="400"/>
 
 ## Purpose


### PR DESCRIPTION
This PR adds a badge for the [MCP Easy Copy](https://glama.ai/mcp/servers/@fisheepx/mcp-easy-copy) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@fisheepx/mcp-easy-copy">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@fisheepx/mcp-easy-copy/badge" alt="Easy Copy MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.